### PR TITLE
Fix oodefine indentation and semicolon

### DIFF
--- a/snippets/js_snippets.json
+++ b/snippets/js_snippets.json
@@ -3,9 +3,9 @@
         "prefix": "oodefine",
         "body": [
             "odoo.define('${1:module_name}', function (require) {",
-            "\"use strict;\"",
+            "\t\"use strict\";",
             "",
-            "${0}",
+            "\t${0}",
             "",
             "});",
             ""


### PR DESCRIPTION
- `"use strict"` was having the `;` inside the string.
- Lines inside the `odoo.define()` method were unindented, violating OCA liter.