### PR TITLE
Fix ooscript tag

### DIFF
--- a/snippets/xml_snippets.json
+++ b/snippets/xml_snippets.json
@@ -341,7 +341,7 @@
     "odoo_script": {
         "prefix": "ooscript",
         "body": [
-            "<script type=\"text/javascript\" href=\"/${1:module_name}/static/src/js/${2:filename}.js\"></script>"
+            "<script type=\"text/javascript\" src=\"/${1:module_name}/static/src/js/${2:filename}.js\"/>"
         ],
         "description": "Add script tag"
     },


### PR DESCRIPTION
`href` attr was wrong. Also, closing tag is automatically added by Odoo, so no need to write it.