### PR TITLE
More useful oofield snippet

### DIFF
--- a/snippets/xml_snippets.json
+++ b/snippets/xml_snippets.json
@@ -415,10 +415,17 @@
         ],
         "description": "Add link tag to include stylesheet"
     },
+    "Self-closing field tag": {
+        "prefix": "oofield",
+        "body": [
+            "<field name=\"${1}\"${2}/>${0}"
+        ],
+        "description": "Add a self-closing field tag"
+    },
     "Field tag": {
         "prefix": "oofield",
         "body": [
-            "<field name=\"${1}\"></field>"
+            "<field name=\"${1}\"${2}>${3}</field>${0}"
         ],
         "description": "Add field tag"
     },


### PR DESCRIPTION
- Add a tab stop after the `name` attribute, to let you add more attributes.
- Allow to choose among a `<field></field>` or a `<field/>`.
- Add a tab stop in the middle of the element if you want a closing tag.
- Add a tab stop in the end.